### PR TITLE
feat: enhance CORS configuration in API

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,19 +12,31 @@ app.use('*', logger())
 
 // CORSミドルウェアを認証の前に配置
 app.options('*', cors({
-  origin: ['http://localhost:3000', 'https://dev.optiverse-now.com', 'https://optiverse-now.com'],
+  origin: [
+    'http://localhost:3000',
+    'https://dev.optiverse-now.com',
+    'https://optiverse-now.com',
+    'https://api.optiverse-now.com',
+    'https://api-dev.optiverse-now.com'
+  ],
   credentials: true,
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowHeaders: ['Content-Type', 'Authorization'],
+  allowHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
   exposeHeaders: ['Content-Length', 'X-Requested-With'],
   maxAge: 86400,
 }))
 
 app.use('*', cors({
-  origin: ['http://localhost:3000', 'https://dev.optiverse-now.com', 'https://optiverse-now.com'],
+  origin: [
+    'http://localhost:3000',
+    'https://dev.optiverse-now.com',
+    'https://optiverse-now.com',
+    'https://api-dev.optiverse-now.com',
+    'https://api.optiverse-now.com'
+  ],
   credentials: true,
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowHeaders: ['Content-Type', 'Authorization'],
+  allowHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
   exposeHeaders: ['Content-Length', 'X-Requested-With'],
   maxAge: 86400,
 }))


### PR DESCRIPTION
- Expanded allowed origins to include 'https://api.optiverse-now.com' and 'https://api-dev.optiverse-now.com' for improved accessibility.
- Updated allowed headers to include 'X-Requested-With' for better client-server communication.
- Maintained existing allowed methods (GET, POST, PUT, DELETE, OPTIONS) and set max age for preflight requests to 86400 seconds.

These changes enhance the API's flexibility and security in managing cross-origin requests.